### PR TITLE
Add eras to User Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
-# README
+# Eras
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+[badges]
+[description]
+[table of contents]
+[content ideas: link to deployed app, setup, test suite, GQL queries and mutations, database schema and description of each table, contributors]
 
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## Local Setup
+- Versions
+  - Rails 6.1.0
+  - Ruby 2.5.3
+- Fork and clone the repository
+- `cd` in your local repo version and run the following commands to install gems and setup database:
+  - `bundle` (if this fails, try to `bundle update` and then retry)
+  - `rails db:create`
+  - `rails db:migrate`
+  - `rails db:seed`
+  - Create a manifest.js file nested under app/assets/config and place the following inside:
+    ```
+    //= link graphiql/rails/application.css
+    //= link graphiql/rails/application.js
+    ```
+    - This file is ignored by git tracking but is necessary to run the server locally.
+- Run your own development server:
+  - In config/applicaiton.rb, uncomment out line 15 (`require "sprockets/railtie"`)
+  - `rails s`
+  - You should be able to access the GraphQL interface via http://localhost:3000/graphiql

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@
     ```
     - This file is ignored by git tracking but is necessary to run the server locally.
 - Run your own development server:
-  - In config/applicaiton.rb, uncomment out line 15 (`require "sprockets/railtie"`)
+  - In config/application.rb, uncomment out line 15 (`require "sprockets/railtie"`)
   - `rails s`
   - You should be able to access the GraphQL interface via http://localhost:3000/graphiql

--- a/app/graphql/types/era_type.rb
+++ b/app/graphql/types/era_type.rb
@@ -1,0 +1,12 @@
+module Types
+  class EraType < Types::BaseObject
+    field :id, ID, null: false
+    field :user_id, ID, null: false
+    field :name, String, null: true
+    field :start_date, String, null: true
+    field :end_date, String, null: true
+    field :color, String, null: true
+    field :created_at, String, null: true
+    field :updated_at, String, null: true
+  end
+end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -4,5 +4,6 @@ module Types
     field :name, String, null: true
     field :email, String, null: true
     field :birthdate, String, null: true
+    field :eras, [Types::EraType], null: false
   end
 end

--- a/spec/requests/graphql/mutations/update_user_spec.rb
+++ b/spec/requests/graphql/mutations/update_user_spec.rb
@@ -15,6 +15,7 @@ module Mutations
           expect(data['name']).to eq('Frosted Flakes Frosty')
           expect(data['email']).to eq('ice@brr.com')
           expect(data['birthdate']).to eq('2000-01-01 00:00:00 UTC')
+          expect(data['eras']).to eq(user.eras.map {|era| { 'id' => era.id.to_s }})
         end
 
         def query(user_id)
@@ -30,6 +31,9 @@ module Mutations
                     name
                     email
                     birthdate
+                    eras {
+                      id
+                    }
                   }
                 }
           GQL

--- a/spec/requests/graphql/queries/users/get_single_user_spec.rb
+++ b/spec/requests/graphql/queries/users/get_single_user_spec.rb
@@ -9,12 +9,27 @@ RSpec.describe Types::QueryType do
       result = JSON.parse(response.body)
 
       expect(result.dig('data',
-                        'getUser')).to eq({
-                                            'id' => user.id.to_s,
-                                            'name' => user.name,
-                                            'email' => user.email,
-                                            'birthdate' => user.birthdate.to_s
-                                          })
+                        'getUser')).to include({
+                                                 'id' => user.id.to_s,
+                                                 'name' => user.name,
+                                                 'email' => user.email,
+                                                 'birthdate' => user.birthdate.to_s
+                                               })
+
+      expect(result['data']['getUser']['eras']).to eq(
+        user.eras.map do |era|
+          {
+            'id' => era.id.to_s,
+            'userId' => era.user_id.to_s,
+            'name' => era.name.to_s,
+            'startDate' => era.start_date.to_s,
+            'endDate' => era.end_date.to_s,
+            'color' => era.color,
+            'createdAt' => era.created_at.to_s,
+            'updatedAt' => era.updated_at.to_s
+          }
+        end
+      )
     end
   end
 
@@ -26,6 +41,16 @@ RSpec.describe Types::QueryType do
           name
           email
           birthdate
+          eras {
+            id
+            userId
+            name
+            startDate
+            endDate
+            color
+            createdAt
+            updatedAt
+          }
         }
       }
     GQL

--- a/spec/requests/graphql/queries/users/get_users_spec.rb
+++ b/spec/requests/graphql/queries/users/get_users_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Types::QueryType do
   describe 'display users' do
     it 'can query all users' do
-      create_list(:user, 2)
+      create_list(:user, 2, :with_eras_events)
 
       post graphql_path, params: { query: query }
       result = JSON.parse(response.body)
@@ -11,9 +11,10 @@ RSpec.describe Types::QueryType do
       expect(result['data']['getUsers'].count).to eq(2)
 
       users = User.all
+
       expect(result.dig('data', 'getUsers')).to match_array(
         users.map do |user|
-          { 'id' => user.id.to_s, 'name' => user.name, 'email' => user.email, 'birthdate' => user.birthdate.to_s }
+          { 'id' => user.id.to_s, 'name' => user.name, 'email' => user.email, 'birthdate' => user.birthdate.to_s, 'eras' => user.eras.map {|era| { 'id' => era.id.to_s }}}
         end
       )
     end
@@ -27,7 +28,10 @@ RSpec.describe Types::QueryType do
           name
           email
           birthdate
+          eras {
+            id
           }
+        }
       }
     GQL
   end


### PR DESCRIPTION
### Code Highlights:
 * Client can now query for a user's eras when doing a user query or mutation
 * They can request any fields available on era type 
 * Updated existing tests to request this new field
 * Added local server setup instructions to readme
   * We may address this workaround in the future but wanted to add them now for reference 

### Where should the reviewer start?
 * get_single_user_spec requests a user's eras including all fields available on era type
 * the rest of the tests just request an era's id

### Have Tests Been Added?
- [ ] No.
- [ ] Yes, but all tests are not passing.
- [x] Yes, and all are passing.

### Issues:
* Closes #43

### Tracking Consistency:
- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] looked at PR preview to check spelling, syntax, formatting, and completion
- [x] Rubocop Violations:
