### PR TITLE
Add `require factory_bot_rails` to spec_helper to attempt to fix seed

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'factory_bot_rails'
+
 require 'simplecov'
 SimpleCov.start 'rails' do
   class BaseFilter < SimpleCov::Filter


### PR DESCRIPTION
### Code Highlights:
 * Adds `require factory_bot_rails` to spec_helper to attempt to fix seeding Heroku
### Where should the reviewer start?
 * `spec_helper`
### Have Tests Been Added?
- [x] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.
### Any background context you want to provide?
### Message/Questions for reviewer:
### Issues:
* Addresses #95 
* Closes #95 
### Screenshots (if appropriate):
### Tracking Consistency:
- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] looked at PR preview to check spelling, syntax, formatting, and completion
- [x] Rubocop Violations:
