### PR TITLE
Move factory_bot_rails 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,12 +27,13 @@ gem 'graphql'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+gem 'factory_bot_rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'pry'
-  gem 'factory_bot_rails'
   gem 'faker'
   gem 'travis'
 end


### PR DESCRIPTION
### Code Highlights:
 * This PR simply moves the `factory_bot_rails` gem out of the `group :development, test do` section into the general gem section.
### Where should the reviewer start?
 * `gemfile`
### Have Tests Been Added?
- [x] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.
### Any background context you want to provide?
- This is an attempt to get `factory_bot` to seed the Heroku DB
### Message/Questions for reviewer:
### Issues:
* Addresses #95 
### Screenshots (if appropriate):
### Tracking Consistency:
- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] looked at PR preview to check spelling, syntax, formatting, and completion
- [x] Rubocop Violations: `Date.today` errors, `def validate(record)` errors, and `get_` errors
