### PR TITLE
Bug fix: set color using .blank instead of .empty 

### DIFF
--- a/app/graphql/mutations/eras/create_era.rb
+++ b/app/graphql/mutations/eras/create_era.rb
@@ -17,7 +17,7 @@ class Mutations::Eras::CreateEra < ::Mutations::BaseMutation
     user_bday = User.where(id: attributes[:user_id])[0].birthdate
     attributes[:start_week] = Mutations::HelperMethods.week_number(start_date, user_bday)
     attributes[:end_week] = Mutations::HelperMethods.week_number(end_date, user_bday)
-    attributes[:color] = Mutations::HelperMethods.set_color if attributes[:color].empty?
+    attributes[:color] = Mutations::HelperMethods.set_color if attributes[:color].blank?
     Era.create!(attributes)
   end
 end

--- a/app/graphql/mutations/events/create_event.rb
+++ b/app/graphql/mutations/events/create_event.rb
@@ -14,7 +14,7 @@ class Mutations::Events::CreateEvent < Mutations::BaseMutation
     event_date = attributes[:date].to_date
     user_bday = User.where(id: attributes[:user_id])[0].birthdate
     attributes[:week_number] = Mutations::HelperMethods.week_number(event_date, user_bday)
-    attributes[:color] = Mutations::HelperMethods.set_color if attributes[:color].empty?
+    attributes[:color] = Mutations::HelperMethods.set_color if attributes[:color].blank?
     Event.create!(attributes)
   end
 end


### PR DESCRIPTION
### Code Highlights:
- use .blank instead of .empty for set color method 

### Have Tests Been Added?
- [x] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.

### Any background context you want to provide?
- set color was returning null to client

### Tracking Consistency:
- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] looked at PR preview to check spelling, syntax, formatting, and completion
- [x] Rubocop Violations:
