### PR TITLE
Get user current week

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,5 +1,7 @@
 module Types
   class QueryType < Types::BaseObject
+    extend Mutations::HelperMethods
+
     field :get_users, [Types::UserType], null: false, description: 'Returns a list of users'
 
     field :get_user, Types::UserType, null: false, description: 'Returns a single user by id' do
@@ -27,7 +29,9 @@ module Types
     end
 
     def get_user(id:)
-      User.find(id)
+      user = User.find(id)
+      user.current_week = Mutations::HelperMethods.week_number(Date.today, user.birthdate)
+      user
     end
 
     # Eras

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -4,6 +4,7 @@ module Types
     field :name, String, null: true
     field :email, String, null: true
     field :birthdate, String, null: true
+    field :current_week, Integer, null: true
     field :events, [Types::EventType], null: false
     field :eras, [Types::EraType], null: false
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
 
   has_many :eras, dependent: :destroy
   has_many :events, dependent: :destroy
+
+  attr_accessor :current_week
 end


### PR DESCRIPTION
### Code Highlights:
 * Adds a [virtual attribute](https://dev.to/andy/til-you-can-add-virtual-attributes-to-rails-models--2cbl) to the User model in order to get it to return the current week
 * Updates the `get_user` query to return the current_week
### Where should the reviewer start?
 * `/api/app/graphql/types/query_type.rb`
### Have Tests Been Added?
- [ ] No.
- [ ] Yes, but all tests are not passing.
- [x] Yes, and all are passing.
### Any background context you want to provide?
- We needed to find a way to add an attribute to the User model that did not need to be saved to the database
### Message/Questions for reviewer:
- Rubocop was complaining about timezone. I wasn't sure if the stub ib my test would work if I added the timezone so I could use some thoughts on that!
### Issues:
* Addresses #
* Closes #116 
### Screenshots (if appropriate):
### Tracking Consistency:
- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] looked at PR preview to check spelling, syntax, formatting, and completion
- [x] Rubocop Violations:
